### PR TITLE
Use getJavaHome from metals-languageclient

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
   },
   "devDependencies": {
     "@types/node": "^13.1.7",
+    "@types/semver": "^6.2.0",
     "coc.nvim": "0.0.74",
     "parcel-bundler": "^1.12.4",
     "prettier": "1.19.1",
@@ -152,9 +153,8 @@
     "typescript": "3.7.5"
   },
   "dependencies": {
-    "@types/semver": "^6.2.0",
     "@types/shell-quote": "^1.6.1",
-    "locate-java-home": "^1.1.2",
+    "metals-languageclient": "^0.1.2",
     "promisify-child-process": "^3.1.3",
     "semver": "^7.1.1",
     "shell-quote": "^1.7.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { detechLauncConfigurationChanges } from "./activationUtils";
 import { Commands } from "./commands";
 import { makeVimDoctor } from "./embeddedDoctor";
-import { getJavaHome, getJavaOptions } from "./javaUtils";
+import { getJavaOptions } from "./javaUtils";
+import { getJavaHome } from "metals-languageclient";
 import {
   ExecuteClientCommand,
   MetalsInputBox,
@@ -47,7 +48,7 @@ export async function activate(context: ExtensionContext) {
   detechLauncConfigurationChanges();
   await checkServerVersion();
 
-  getJavaHome()
+  getJavaHome(workspace.getConfiguration("metals").get("javaHome"))
     .then(javaHome => fetchAndLaunchMetals(context, javaHome))
     .catch(_ => {
       const message =

--- a/src/javaUtils.ts
+++ b/src/javaUtils.ts
@@ -1,39 +1,7 @@
-import locateJavaHome from "locate-java-home";
 import { workspace } from "coc.nvim";
 import { parse } from "shell-quote";
-import * as semver from "semver";
 import * as fs from "fs";
 import * as path from "path";
-
-export function getJavaHome(): Promise<string> {
-  const userJavaHome = workspace.getConfiguration("metals").get("javaHome");
-  if (typeof userJavaHome === "string" && userJavaHome.trim() !== "") {
-    return Promise.resolve(userJavaHome);
-  } else {
-    const JAVA_HOME = process.env["JAVA_HOME"];
-    if (JAVA_HOME) return Promise.resolve(JAVA_HOME);
-    else {
-      return new Promise((resolve, reject) => {
-        locateJavaHome({ version: ">=1.8 <=1.11" }, (err, javaHomes) => {
-          if (err) {
-            reject(err);
-          } else if (!javaHomes || javaHomes.length === 0) {
-            reject(new Error("No suitable Java version found"));
-          } else {
-            javaHomes.sort((a, b) => {
-              const byVersion = -semver.compare(a.version, b.version);
-              if (byVersion === 0) return b.security - a.security;
-              else return byVersion;
-            });
-            const jdkHome = javaHomes.find(j => j.isJDK);
-            if (jdkHome) resolve(jdkHome.path);
-            else resolve(javaHomes[0].path);
-          }
-        });
-      });
-    }
-  }
-}
 
 function javaOpts(): string[] {
   function expandVariable(variable: string | undefined): string[] {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2354,6 +2354,11 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+fp-ts@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.4.1.tgz#d20c785ff8179930922c7477c31f1ca44f763ae9"
+  integrity sha512-dPal5+rPN7k4ciZ2+O0+i75bbp17uTUoRkWWqJpkKed7wVcA5y/2jH4ZhunzUrJPuaG+mN9ZNf0pv5P7u/k7JQ==
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -3264,6 +3269,15 @@ merge2@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
   integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
+
+metals-languageclient@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.1.2.tgz#153a8eff0162822fa5588784b2f763979e5aed6e"
+  integrity sha512-LLPliQbvsRyCK1/WACmkBzRX6sxcS7Sr/vIrc3+52rXFcDV94ag8dhVZVO6Y8bnpBQtlxrUnBTk2WzyKDwCDpQ==
+  dependencies:
+    fp-ts "^2.4.1"
+    locate-java-home "^1.1.2"
+    semver "^7.1.1"
 
 micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"


### PR DESCRIPTION
This is a first step towards deduplicating logic between `metals-vscode` and `coc-metals`, by centralizing the shared logic in `metals-languageclient`