### PR TITLE
Minor contributing clarification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ They have a great wiki with a lot of resources about how to configure and use `c
 specific page dedicated to extension which can be found [here](https://github.com/neoclide/coc.nvim/wiki/Using-coc-extensions).
 
 `coc.nvim` will try to load extensions that are located under `$VIMCONFIG/coc/extensions`. What I've found to be
-the easiest to do while developing is to add `coc-metals` to dependences in the `package.json` file located
+the easiest to do while developing is to add `"coc-metals": "*"` to dependences in the `package.json` file located
 in this directory. Then, create a symbolic link from where you have cloned this repo to the `node_modules` directory.
 On my machine, it looks like this.
 


### PR DESCRIPTION
I just followed these instructions. It took me a while to realise that adding "coc-metals" verbatim to the package.json file is insufficient. In hindsight it seems obvious that the version should be required, but maybe this change will save someone else some time in the future.