### PR TITLE
remove catch and only show generated msg

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,11 +100,11 @@ function fetchAndLaunchMetals(context: ExtensionContext, javaHome: string) {
     javaConfig
   });
 
-  trackDownloadProgress(fetchProcess)
-    .then(classpath => {
+  trackDownloadProgress(fetchProcess).then(
+    classpath => {
       launchMetals(context, classpath, serverProperties, javaConfig);
-    })
-    .catch(err => {
+    },
+    () => {
       const msg = (() => {
         const proxy =
           `See https://scalaeta.org/metals/docs/editors/vscode.html#http-proxy for instructions ` +
@@ -124,12 +124,11 @@ function fetchAndLaunchMetals(context: ExtensionContext, javaHome: string) {
           );
         }
       })();
-      workspace
-        .showPrompt(`${err.message}\n ${msg}\n Open Settings?`)
-        .then(choice => {
-          if (choice) workspace.nvim.command(Commands.OPEN_COC_CONFIG, true);
-        });
-    });
+      workspace.showPrompt(`${msg}\n Open Settings?`).then(choice => {
+        if (choice) workspace.nvim.command(Commands.OPEN_COC_CONFIG, true);
+      });
+    }
+  );
 }
 
 function launchMetals(


### PR DESCRIPTION
Previously I was catching the error if a download would fail. I _believe_ I may have originally did this to just see better what was happening. However, this is unnecessary it just pollutes the message window in vim showing them stuff the don't need to see.