### PR TITLE
Add moved properties clientExperimentalCapabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
   },
   "dependencies": {
     "coc.nvim": "0.0.74",
-    "metals-languageclient": "0.1.17",
+    "metals-languageclient": "0.1.19",
     "promisify-child-process": "^3.1.3",
     "vscode-languageserver-protocol": "3.15.0-next.6"
   },

--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -10,6 +10,7 @@ export interface QuickPickProvider {}
 export interface InputBoxProvider {}
 export interface DidFocusProvider {}
 export interface SlowTaskProvider {}
+export interface ExecuteClientCommandProvider {}
 
 export class MetalsFeatures implements StaticFeature {
   debuggingProvider?: DebuggingProvider;
@@ -18,6 +19,7 @@ export class MetalsFeatures implements StaticFeature {
   inputBoxProvider?: InputBoxProvider;
   didFocusProvider?: DidFocusProvider;
   slowTaskProvider?: SlowTaskProvider;
+  executeClientCommandProvider?: ExecuteClientCommandProvider;
 
   fillInitializeParams(params: InitializeParams): void {
     if (!params.capabilities.experimental) {
@@ -30,6 +32,8 @@ export class MetalsFeatures implements StaticFeature {
     (params.capabilities.experimental as any).inputBoxProvider = true;
     (params.capabilities.experimental as any).didFocusProvider = true;
     (params.capabilities.experimental as any).slowTaskProvider = false;
+    (params.capabilities
+      .experimental as any).executeClientCommandProvider = true;
   }
   fillClientCapabilities(): void {}
   initialize(capabilities: ServerCapabilities): void {
@@ -40,6 +44,8 @@ export class MetalsFeatures implements StaticFeature {
       this.inputBoxProvider = capabilities.experimental.inputBoxProvider;
       this.didFocusProvider = capabilities.experimental.didFocusProvider;
       this.slowTaskProvider = capabilities.experimental.slowTaskProvider;
+      this.executeClientCommandProvider =
+        capabilities.experimental.executeClientCommandProvider;
     }
   }
 }

--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -11,6 +11,7 @@ export interface InputBoxProvider {}
 export interface DidFocusProvider {}
 export interface SlowTaskProvider {}
 export interface ExecuteClientCommandProvider {}
+export interface DoctorProvider {}
 
 export class MetalsFeatures implements StaticFeature {
   debuggingProvider?: DebuggingProvider;
@@ -20,6 +21,7 @@ export class MetalsFeatures implements StaticFeature {
   didFocusProvider?: DidFocusProvider;
   slowTaskProvider?: SlowTaskProvider;
   executeClientCommandProvider?: ExecuteClientCommandProvider;
+  doctorProvider?: DoctorProvider;
 
   fillInitializeParams(params: InitializeParams): void {
     if (!params.capabilities.experimental) {
@@ -34,6 +36,7 @@ export class MetalsFeatures implements StaticFeature {
     (params.capabilities.experimental as any).slowTaskProvider = false;
     (params.capabilities
       .experimental as any).executeClientCommandProvider = true;
+    (params.capabilities.experimental as any).doctorProvider = "json";
   }
   fillClientCapabilities(): void {}
   initialize(capabilities: ServerCapabilities): void {
@@ -46,6 +49,7 @@ export class MetalsFeatures implements StaticFeature {
       this.slowTaskProvider = capabilities.experimental.slowTaskProvider;
       this.executeClientCommandProvider =
         capabilities.experimental.executeClientCommandProvider;
+      this.doctorProvider = capabilities.experimental.doctorProvider;
     }
   }
 }

--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -12,6 +12,7 @@ export interface DidFocusProvider {}
 export interface SlowTaskProvider {}
 export interface ExecuteClientCommandProvider {}
 export interface DoctorProvider {}
+export interface StatusBarProvider {}
 
 export class MetalsFeatures implements StaticFeature {
   debuggingProvider?: DebuggingProvider;
@@ -22,6 +23,7 @@ export class MetalsFeatures implements StaticFeature {
   slowTaskProvider?: SlowTaskProvider;
   executeClientCommandProvider?: ExecuteClientCommandProvider;
   doctorProvider?: DoctorProvider;
+  statusBarProvider?: StatusBarProvider;
 
   fillInitializeParams(params: InitializeParams): void {
     if (!params.capabilities.experimental) {
@@ -37,6 +39,8 @@ export class MetalsFeatures implements StaticFeature {
     (params.capabilities
       .experimental as any).executeClientCommandProvider = true;
     (params.capabilities.experimental as any).doctorProvider = "json";
+    (params.capabilities.experimental as any).statusBarProvider =
+      "show-message";
   }
   fillClientCapabilities(): void {}
   initialize(capabilities: ServerCapabilities): void {
@@ -50,6 +54,7 @@ export class MetalsFeatures implements StaticFeature {
       this.executeClientCommandProvider =
         capabilities.experimental.executeClientCommandProvider;
       this.doctorProvider = capabilities.experimental.doctorProvider;
+      this.statusBarProvider = capabilities.experimental.statusBarProvider;
     }
   }
 }

--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -9,6 +9,7 @@ export interface DecorationProvider {}
 export interface QuickPickProvider {}
 export interface InputBoxProvider {}
 export interface DidFocusProvider {}
+export interface SlowTaskProvider {}
 
 export class MetalsFeatures implements StaticFeature {
   debuggingProvider?: DebuggingProvider;
@@ -16,6 +17,7 @@ export class MetalsFeatures implements StaticFeature {
   quickPickProvider?: QuickPickProvider;
   inputBoxProvider?: InputBoxProvider;
   didFocusProvider?: DidFocusProvider;
+  slowTaskProvider?: SlowTaskProvider;
 
   fillInitializeParams(params: InitializeParams): void {
     if (!params.capabilities.experimental) {
@@ -27,6 +29,7 @@ export class MetalsFeatures implements StaticFeature {
     (params.capabilities.experimental as any).quickPickProvider = true;
     (params.capabilities.experimental as any).inputBoxProvider = true;
     (params.capabilities.experimental as any).didFocusProvider = true;
+    (params.capabilities.experimental as any).slowTaskProvider = false;
   }
   fillClientCapabilities(): void {}
   initialize(capabilities: ServerCapabilities): void {
@@ -36,6 +39,7 @@ export class MetalsFeatures implements StaticFeature {
       this.quickPickProvider = capabilities.experimental.quickPickProvider;
       this.inputBoxProvider = capabilities.experimental.inputBoxProvider;
       this.didFocusProvider = capabilities.experimental.didFocusProvider;
+      this.slowTaskProvider = capabilities.experimental.slowTaskProvider;
     }
   }
 }

--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -8,12 +8,14 @@ export interface DebuggingProvider {}
 export interface DecorationProvider {}
 export interface QuickPickProvider {}
 export interface InputBoxProvider {}
+export interface DidFocusProvider {}
 
 export class MetalsFeatures implements StaticFeature {
   debuggingProvider?: DebuggingProvider;
   decorationProvider?: DecorationProvider;
   quickPickProvider?: QuickPickProvider;
   inputBoxProvider?: InputBoxProvider;
+  didFocusProvider?: DidFocusProvider;
 
   fillInitializeParams(params: InitializeParams): void {
     if (!params.capabilities.experimental) {
@@ -24,6 +26,7 @@ export class MetalsFeatures implements StaticFeature {
       workspace.isNvim;
     (params.capabilities.experimental as any).quickPickProvider = true;
     (params.capabilities.experimental as any).inputBoxProvider = true;
+    (params.capabilities.experimental as any).didFocusProvider = true;
   }
   fillClientCapabilities(): void {}
   initialize(capabilities: ServerCapabilities): void {
@@ -32,6 +35,7 @@ export class MetalsFeatures implements StaticFeature {
       this.decorationProvider = capabilities.experimental.decorationProvider;
       this.quickPickProvider = capabilities.experimental.quickPickProvider;
       this.inputBoxProvider = capabilities.experimental.inputBoxProvider;
+      this.didFocusProvider = capabilities.experimental.didFocusProvider;
     }
   }
 }

--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -7,11 +7,13 @@ import { StaticFeature, workspace } from "coc.nvim";
 export interface DebuggingProvider {}
 export interface DecorationProvider {}
 export interface QuickPickProvider {}
+export interface InputBoxProvider {}
 
 export class MetalsFeatures implements StaticFeature {
   debuggingProvider?: DebuggingProvider;
   decorationProvider?: DecorationProvider;
   quickPickProvider?: QuickPickProvider;
+  inputBoxProvider?: InputBoxProvider;
 
   fillInitializeParams(params: InitializeParams): void {
     if (!params.capabilities.experimental) {
@@ -21,6 +23,7 @@ export class MetalsFeatures implements StaticFeature {
     (params.capabilities.experimental as any).decorationProvider =
       workspace.isNvim;
     (params.capabilities.experimental as any).quickPickProvider = true;
+    (params.capabilities.experimental as any).inputBoxProvider = true;
   }
   fillClientCapabilities(): void {}
   initialize(capabilities: ServerCapabilities): void {
@@ -28,6 +31,7 @@ export class MetalsFeatures implements StaticFeature {
       this.debuggingProvider = capabilities.experimental.debuggingProvider;
       this.decorationProvider = capabilities.experimental.decorationProvider;
       this.quickPickProvider = capabilities.experimental.quickPickProvider;
+      this.inputBoxProvider = capabilities.experimental.inputBoxProvider;
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,8 +144,7 @@ function launchMetals(
     metalsClasspath,
     serverProperties,
     javaConfig,
-    clientName: "coc-metals",
-    doctorFormat: "json"
+    clientName: "coc-metals"
   });
 
   const clientOptions: LanguageClientOptions = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3280,10 +3280,10 @@ merge2@^1.2.3:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
   integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
 
-metals-languageclient@0.1.17:
-  version "0.1.17"
-  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.1.17.tgz#66340f991204d9d5d378014fc67224dfd4c05360"
-  integrity sha512-BsZFtWtEGSnEqlS9ICxII2CSsDBk3JreviwB5ejxF74nAlevEEuSTEyDjekRxEBBTbv6aDo/V+ac++hSbYT2dg==
+metals-languageclient@0.1.19:
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.1.19.tgz#6eaae47103c438aec86d24e16e585c434e2d6829"
+  integrity sha512-1dWW9OLwUUSfVSHjDpsMUkuNp6dQuaBgRPJGV90Bq+6TGmZOHYK07RdCQFXCQh0Wk3HBWlTdc5wPl/Q9O3kZPw==
   dependencies:
     fp-ts "^2.4.1"
     locate-java-home "^1.1.2"


### PR DESCRIPTION
This is an example of how inputBox can actually just be set as an experimental feature rather than a server property.

Here is the corresponding Metals ticket with more context: https://github.com/scalameta/metals/pull/1414