### PR TITLE
don't let user create a file with a blank name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -274,16 +274,20 @@ function launchMetals(
           "Name: ",
           ""
         ]);
-        const arg: MetalsNewScalaFileParams = {
-          directory: parentDir,
-          name: fileName,
-          kind: desiredFileType.kind
-        };
-        const result = await client.sendRequest(ExecuteCommandRequest.type, {
-          command: "new-scala-file",
-          arguments: [arg]
-        });
-        workspace.openResource(result);
+        if (fileName === "") {
+          workspace.showMessage("New file must have a name.", "error");
+        } else {
+          const arg: MetalsNewScalaFileParams = {
+            directory: parentDir,
+            name: fileName,
+            kind: desiredFileType.kind
+          };
+          const result = await client.sendRequest(ExecuteCommandRequest.type, {
+            command: "new-scala-file",
+            arguments: [arg]
+          });
+          workspace.openResource(result);
+        }
       } else {
         return;
       }


### PR DESCRIPTION
Should have thought of this before. I tested with no choice, but didn't think about choosing an option and then providing a blank name. This will block that from happening.