### PR TITLE
Integration with vimspector

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,7 @@ synced with the latest stable release***
   - [Shut down the language server](#shut-down-the-language-server)
   - [Statusline integration](#statusline-integration)
   - [Formatting on save](#formatting-on-save)
+  - [Debugging](#debugging)
   - [Gitignore](#gitignore)
   - [Troubleshooting](#troubleshooting)
   - [Contributing](#contributing)
@@ -411,6 +412,66 @@ have the following in your `:CocConfig`.
 ```json
 "coc.preferences.formatOnSaveFiletypes": ["scala"]
 ```
+
+### Debugging
+
+Coc-metals provides smooth integration with [vimspector](https://github.com/puremourning/vimspector)
+and allows to run Debug Adapter Server and debug your application with minimum
+manual steps.
+
+Requirements:
+* Neovim 0.4.3 with Python 3.6 or later (Vim is not supported because codeLens in Coc
+are implemented using 'virtual text' feature of Neovim and are not available in Vim.
+CodeLens are used to run Debug Adapter Server).
+* Plugin [vimspector](https://github.com/puremourning/vimspector). Basically you just
+need to add vimspector into vim's runtimepath, for example, if you are using vim-plug then
+add this line in .vimrc
+```vim
+Plug 'puremourning/vimspector'
+```
+
+Configuration:
+* Set `codeLens.enable` to `true` in your Coc Config.
+* Configure vimspector in .vimrc
+```vim
+let g:vimspector_enable_mappings = 'HUMAN'
+```
+Please refer vimspector documentation for more configuration options.
+* Put file `cocmetals.json` in directory `/path/to/vimspector/configurations/{os}/scala`
+(where `os` is `linux`, `macos` or `windows`) with following content:
+```json
+{
+  "configurations": {
+    "cocmetals": {
+      "adapter": {
+        "port": "${port}",
+        "variables": {
+        }
+      },
+      "configuration": {
+        "request": "launch"
+      },
+      "breakpoints": {
+        "exception": {
+          "caught": "N",
+          "uncaught": "N"
+        }
+      }
+    }
+  }
+}
+```
+
+
+With these configuration parameters the codeLens 'run' and 'debug' appears against runnable
+classes (applications or tests) of your project. Then, you will be able to trigger these
+codeLens actions (default mapping is `<leader> cl`) and start Debug Adapter Server. Once
+Debug Adapter Server is started coc-metals will transfer necessary information to vimspector
+to activate debugging.
+
+For now both actions 'run' and 'debug' start vimspector in debug mode. This may be improved
+in next versions.
+
 ### Gitignore
 
 The Metals server places logs and other files in the .metals/ directory. The

--- a/src/DebuggingFeature.ts
+++ b/src/DebuggingFeature.ts
@@ -2,10 +2,8 @@ import { BaseLanguageClient, StaticFeature, Neovim } from "coc.nvim";
 import {
   ExecuteCommandParams,
   ExecuteCommandRequest,
-  InitializeParams,
-  ServerCapabilities,
 } from "vscode-languageserver-protocol";
-import { commands, workspace } from "coc.nvim";
+import { commands } from "coc.nvim";
 
 interface DebugAdapterStartResponse {
   name: string;
@@ -13,65 +11,45 @@ interface DebugAdapterStartResponse {
 }
 
 export class DebuggingFeature implements StaticFeature {
-  private withVimspector = false;
-
   constructor(private _nvim: Neovim, private _client: BaseLanguageClient) {}
 
-  async preInit(): Promise<void> {
-    this.withVimspector = (await this._nvim.getVar("loaded_vimpector")) === 1;
-  }
-
-  fillInitializeParams(params: InitializeParams): void {
-    if (params.capabilities.experimental == null) {
-      params.capabilities.experimental = {};
-    }
-    (params.capabilities.experimental as any).debuggingProvider =
-      workspace.isNvim && this.withVimspector;
-  }
+  fillInitializeParams(): void {}
 
   fillClientCapabilities(): void {}
 
-  public initialize(capabilities: ServerCapabilities): void {
-    if (
-      this.withVimspector &&
-      capabilities.experimental &&
-      capabilities.experimental.debuggingProvider
-    ) {
-      const debugHandler = async (_: boolean, ...args: any[]) => {
-        let params: ExecuteCommandParams = {
-          command: "debug-adapter-start",
-          arguments: args,
-        };
-        return this._client
-          .sendRequest(ExecuteCommandRequest.type, params)
-          .then(
-            async (resp: DebugAdapterStartResponse) => {
-              const colonIdx = resp.uri.lastIndexOf(":");
-              if (colonIdx !== -1) {
-                const port = parseInt(resp.uri.substr(colonIdx + 1));
-                await this._nvim.call("vimspector#LaunchWithSettings", [
-                  { configuration: "cocmetals", port },
-                ]);
-              }
-            },
-            (error) => {
-              this._client.logFailedRequest(ExecuteCommandRequest.type, error);
-            }
-          );
+  public initialize(): void {
+    const debugHandler = async (_: boolean, ...args: any[]) => {
+      let params: ExecuteCommandParams = {
+        command: "debug-adapter-start",
+        arguments: args,
       };
+      return this._client.sendRequest(ExecuteCommandRequest.type, params).then(
+        async (resp: DebugAdapterStartResponse) => {
+          const colonIdx = resp.uri.lastIndexOf(":");
+          if (colonIdx !== -1) {
+            const port = parseInt(resp.uri.substr(colonIdx + 1));
+            await this._nvim.call("vimspector#LaunchWithSettings", [
+              { configuration: "cocmetals", port },
+            ]);
+          }
+        },
+        (error) => {
+          this._client.logFailedRequest(ExecuteCommandRequest.type, error);
+        }
+      );
+    };
 
-      commands.registerCommand(
-        "metals-run-session-start",
-        debugHandler.bind(this, false),
-        null,
-        true
-      );
-      commands.registerCommand(
-        "metals-debug-session-start",
-        debugHandler.bind(this, true),
-        null,
-        true
-      );
-    }
+    commands.registerCommand(
+      "metals-run-session-start",
+      debugHandler.bind(this, false),
+      null,
+      true
+    );
+    commands.registerCommand(
+      "metals-debug-session-start",
+      debugHandler.bind(this, true),
+      null,
+      true
+    );
   }
 }

--- a/src/DebuggingFeature.ts
+++ b/src/DebuggingFeature.ts
@@ -1,0 +1,77 @@
+import { BaseLanguageClient, StaticFeature, Neovim } from "coc.nvim";
+import {
+  ExecuteCommandParams,
+  ExecuteCommandRequest,
+  InitializeParams,
+  ServerCapabilities,
+} from "vscode-languageserver-protocol";
+import { commands, workspace } from "coc.nvim";
+
+interface DebugAdapterStartResponse {
+  name: string;
+  uri: string;
+}
+
+export class DebuggingFeature implements StaticFeature {
+  private withVimspector = false;
+
+  constructor(private _nvim: Neovim, private _client: BaseLanguageClient) {}
+
+  async preInit(): Promise<void> {
+    this.withVimspector = (await this._nvim.getVar("loaded_vimpector")) === 1;
+  }
+
+  fillInitializeParams(params: InitializeParams): void {
+    if (params.capabilities.experimental == null) {
+      params.capabilities.experimental = {};
+    }
+    (params.capabilities.experimental as any).debuggingProvider =
+      workspace.isNvim && this.withVimspector;
+  }
+
+  fillClientCapabilities(): void {}
+
+  public initialize(capabilities: ServerCapabilities): void {
+    if (
+      this.withVimspector &&
+      capabilities.experimental &&
+      capabilities.experimental.debuggingProvider
+    ) {
+      const debugHandler = async (_: boolean, ...args: any[]) => {
+        let params: ExecuteCommandParams = {
+          command: "debug-adapter-start",
+          arguments: args,
+        };
+        return this._client
+          .sendRequest(ExecuteCommandRequest.type, params)
+          .then(
+            async (resp: DebugAdapterStartResponse) => {
+              const colonIdx = resp.uri.lastIndexOf(":");
+              if (colonIdx !== -1) {
+                const port = parseInt(resp.uri.substr(colonIdx + 1));
+                await this._nvim.call("vimspector#LaunchWithSettings", [
+                  { configuration: "cocmetals", port },
+                ]);
+              }
+            },
+            (error) => {
+              this._client.logFailedRequest(ExecuteCommandRequest.type, error);
+            }
+          );
+      };
+
+      commands.registerCommand(
+        "metals-run-session-start",
+        debugHandler.bind(this, false),
+        null,
+        true
+      );
+      commands.registerCommand(
+        "metals-debug-session-start",
+        debugHandler.bind(this, true),
+        null,
+        true
+      );
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,29 +48,7 @@ import {
   trackDownloadProgress,
   wait,
 } from "./utils";
-import {
-  commands,
-  ExtensionContext,
-  LanguageClient,
-  LanguageClientOptions,
-  RevealOutputChannelOn,
-  workspace,
-  events,
-  FloatFactory,
-  StatusBarItem
-} from "coc.nvim";
-import {
-  ExecuteCommandRequest,
-  Location
-} from "vscode-languageserver-protocol";
 import { DebuggingFeature } from "./DebuggingFeature";
-import { MetalsFeatures } from "./MetalsFeatures";
-import DecorationProvider from "./decoration";
-import { InputBoxOptions } from "./portedProtocol";
-import { TreeViewController } from "./tvp/controller";
-import { TreeViewFeature } from "./tvp/feature";
-import { TreeViewsManager } from "./tvp/treeviews";
-import * as path from "path";
 import WannaBeStatusBarItem from "./WannaBeStatusBarItem";
 
 export async function activate(context: ExtensionContext) {
@@ -369,6 +347,10 @@ async function launchMetals(
           break;
         case "metals-logs-toggle":
           toggleLogs();
+          break;
+        case "metals-model-refresh":
+          // CodeLensManager from coc.nvim reloads codeLens on this event
+          events.fire("BufEnter", [workspace.bufnr]);
           break;
         default:
           workspace.showMessage(`Recieved unknown command: ${params.command}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,29 @@ import {
   trackDownloadProgress,
   wait,
 } from "./utils";
+import {
+  commands,
+  ExtensionContext,
+  LanguageClient,
+  LanguageClientOptions,
+  RevealOutputChannelOn,
+  workspace,
+  events,
+  FloatFactory,
+  StatusBarItem
+} from "coc.nvim";
+import {
+  ExecuteCommandRequest,
+  Location
+} from "vscode-languageserver-protocol";
+import { DebuggingFeature } from "./DebuggingFeature";
+import { MetalsFeatures } from "./MetalsFeatures";
+import DecorationProvider from "./decoration";
+import { InputBoxOptions } from "./portedProtocol";
+import { TreeViewController } from "./tvp/controller";
+import { TreeViewFeature } from "./tvp/feature";
+import { TreeViewsManager } from "./tvp/treeviews";
+import * as path from "path";
 import WannaBeStatusBarItem from "./WannaBeStatusBarItem";
 
 export async function activate(context: ExtensionContext) {
@@ -159,7 +182,7 @@ function fetchAndLaunchMetals(
   );
 }
 
-function launchMetals(
+async function launchMetals(
   context: ExtensionContext,
   metalsClasspath: string,
   serverProperties: string[],
@@ -200,7 +223,10 @@ function launchMetals(
   );
 
   const treeViewFeature = new TreeViewFeature(client);
+  const debuggingFeature = new DebuggingFeature(workspace.nvim, client);
+  await debuggingFeature.preInit();
   client.registerFeature(treeViewFeature);
+  client.registerFeature(debuggingFeature);
 
   const floatFactory = new FloatFactory(
     workspace.nvim,

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,6 +190,10 @@ async function launchMetals(
       inputBoxProvider: true,
       slowTaskProvider: true,
       statusBarProvider: statusBarEnabled ? "on" : "show-message",
+      treeViewProvider: true,
+      debuggingProvider:
+        workspace.isNvim &&
+        (await workspace.nvim.getVar("loaded_vimpector")) === 1,
     },
   };
 
@@ -201,10 +205,11 @@ async function launchMetals(
   );
 
   const treeViewFeature = new TreeViewFeature(client);
-  const debuggingFeature = new DebuggingFeature(workspace.nvim, client);
-  await debuggingFeature.preInit();
   client.registerFeature(treeViewFeature);
-  client.registerFeature(debuggingFeature);
+  if (clientOptions.initializationOptions.debuggingProvider) {
+    const debuggingFeature = new DebuggingFeature(workspace.nvim, client);
+    client.registerFeature(debuggingFeature);
+  }
 
   const floatFactory = new FloatFactory(
     workspace.nvim,

--- a/src/tvp/feature.ts
+++ b/src/tvp/feature.ts
@@ -15,7 +15,6 @@ import {
   MetalsTreeViewVisibilityDidChange,
 } from "metals-languageclient";
 import {
-  ClientCapabilities,
   Disposable,
   Emitter,
   ExecuteCommandParams,
@@ -44,12 +43,7 @@ export class TreeViewFeature implements DynamicFeature<void> {
     return this.requestType;
   }
 
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    if (capabilities.experimental == null) {
-      capabilities.experimental = {};
-    }
-    (capabilities.experimental as any).treeViewProvider = true;
-  }
+  public fillClientCapabilities(): void {}
 
   public initialize(capabilities: ServerCapabilities): void {
     if (!capabilities.experimental!.treeViewProvider) return;


### PR DESCRIPTION
Settings:
1. "codeLens.enable" must be set to true in CocConfig
2. Need latest version of vimspector
3. File `/path/to/vimspector/configurations/linux/scala/cocmetals.json`
```
{
  "configurations": {
    "cocmetals": {
      "adapter": {
        "port": "${port}",
        "variables": {
        }
      },
      "configuration": {
        "request": "launch"
      },
      "breakpoints": {
        "exception": {
          "caught": "N",
          "uncaught": "N"
        }
      }
    }
  }
}
```