### PR TITLE
add in new way to create a scala file

### DIFF
--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -6,10 +6,12 @@ import { StaticFeature, workspace } from "coc.nvim";
 
 export interface DebuggingProvider {}
 export interface DecorationProvider {}
+export interface QuickPickProvider {}
 
 export class MetalsFeatures implements StaticFeature {
   debuggingProvider?: DebuggingProvider;
   decorationProvider?: DecorationProvider;
+  quickPickProvider?: QuickPickProvider;
 
   fillInitializeParams(params: InitializeParams): void {
     if (!params.capabilities.experimental) {
@@ -18,12 +20,14 @@ export class MetalsFeatures implements StaticFeature {
     (params.capabilities.experimental as any).debuggingProvider = false;
     (params.capabilities.experimental as any).decorationProvider =
       workspace.isNvim;
+    (params.capabilities.experimental as any).quickPickProvider = true;
   }
   fillClientCapabilities(): void {}
   initialize(capabilities: ServerCapabilities): void {
     if (capabilities.experimental) {
       this.debuggingProvider = capabilities.experimental.debuggingProvider;
       this.decorationProvider = capabilities.experimental.decorationProvider;
+      this.quickPickProvider = capabilities.experimental.quickPickProvider;
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -294,14 +294,12 @@ function launchMetals(
 
     client.onRequest(MetalsInputBox.type, async (options: InputBoxOptions) => {
       const response = await workspace.callAsync<string>("input", [
-        `${options.prompt} `,
+        `${options.prompt}: `,
         options.value ? options.value : ""
       ]);
-      workspace.showMessage(response);
       if (response.trim() === "") {
         return { cancelled: true };
       } else {
-        workspace.showMessage(response);
         return { value: response };
       }
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,12 +11,12 @@ import {
 } from "metals-languageclient";
 import {
   ExecuteClientCommand,
-  MetalsInputBox,
   MetalsDidFocus,
+  MetalsInputBox,
+  MetalsQuickPick,
   DecorationsRangesDidChange,
   PublishDecorationsParams,
-  MetalsNewScalaFileParams,
-  NewFileOptions
+  MetalsQuickPickParams
 } from "./metalsProtocol";
 import {
   checkServerVersion,
@@ -238,59 +238,10 @@ function launchMetals(
       const currentPath = currentDoc.uri;
       const parentDir = path.dirname(currentPath);
 
-      const fileOptions: NewFileOptions[] = [
-        {
-          kind: "class",
-          label: "Class"
-        },
-        {
-          kind: "object",
-          label: "Object"
-        },
-        {
-          kind: "trait",
-          label: "Trait"
-        },
-        {
-          kind: "package-object",
-          label: "Package Object"
-        },
-        {
-          kind: "worksheet",
-          label: "Worksheet"
-        }
-      ];
-
-      const fileSelection = await workspace.showQuickpick(
-        fileOptions.map(option => option.label),
-        "Select the kind of file to create"
-      );
-
-      const desiredFileType: NewFileOptions | undefined =
-        fileOptions[fileSelection];
-
-      if (desiredFileType !== undefined) {
-        const fileName = await workspace.callAsync<string>("input", [
-          "Name: ",
-          ""
-        ]);
-        if (fileName.trim() === "") {
-          workspace.showMessage("New file must have a name.", "error");
-        } else {
-          const arg: MetalsNewScalaFileParams = {
-            directory: parentDir,
-            name: fileName,
-            kind: desiredFileType.kind
-          };
-          const result = await client.sendRequest(ExecuteCommandRequest.type, {
-            command: "new-scala-file",
-            arguments: [arg]
-          });
-          workspace.openResource(result);
-        }
-      } else {
-        return;
-      }
+      client.sendRequest(ExecuteCommandRequest.type, {
+        command: "new-scala-file",
+        arguments: [parentDir]
+      });
     });
 
     client.onNotification(ExecuteClientCommand.type, async params => {
@@ -344,15 +295,31 @@ function launchMetals(
     client.onRequest(MetalsInputBox.type, async (options: InputBoxOptions) => {
       const response = await workspace.callAsync<string>("input", [
         `${options.prompt} `,
-        options.value
+        options.value ? options.value : ""
       ]);
-      if (response === undefined) {
+      workspace.showMessage(response);
+      if (response.trim() === "") {
         return { cancelled: true };
       } else {
         workspace.showMessage(response);
         return { value: response };
       }
     });
+
+    client.onRequest(MetalsQuickPick.type, (params: MetalsQuickPickParams, _) =>
+      workspace
+        .showQuickpick(
+          params.items.map(item => item.label),
+          params.placeHolder
+        )
+        .then(answer => {
+          if (answer === -1) {
+            return { cancelled: true };
+          } else {
+            return { itemId: params.items[answer].id };
+          }
+        })
+    );
 
     if (features.decorationProvider) {
       client.onNotification(

--- a/src/metalsProtocol.ts
+++ b/src/metalsProtocol.ts
@@ -61,13 +61,32 @@ export namespace MetalsDidFocus {
   );
 }
 
-export interface MetalsNewScalaFileParams {
-  directory?: string;
-  name: string;
-  kind: "class" | "object" | "trait" | "package-object" | "worksheet";
+export namespace MetalsQuickPick {
+  export const type = new RequestType<
+    MetalsQuickPickParams,
+    MetalsQuickPickResult,
+    void,
+    void
+  >("metals/quickPick");
 }
 
-export interface NewFileOptions {
-  kind: "class" | "object" | "trait" | "package-object" | "worksheet";
-  label: "Class" | "Object" | "Trait" | "Package Object" | "Worksheet";
+export interface MetalsQuickPickParams {
+  items: MetalsQuickPickItem[];
+  matchOnDescription?: boolean;
+  matchOnDetail?: boolean;
+  placeHolder?: string;
+  ignoreFocusOut?: boolean;
+}
+
+export interface MetalsQuickPickResult {
+  itemId?: string;
+  cancelled?: boolean;
+}
+
+export interface MetalsQuickPickItem {
+  id: string;
+  label: string;
+  description?: string;
+  detail?: string;
+  alwaysShow?: boolean;
 }


### PR DESCRIPTION
This implements the new way to create a Scala file with the `quickPickProvider` instead of the original implementation. This can first be merged after https://github.com/scalameta/metals/pull/1447 is merged. You can also find more details there.