### PR TITLE
Add in implementation for user configuration to turn statusBar on or off

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
         },
         "metals.statusBarEnabled": {
           "type": "boolean",
-          "default": true
+          "default": false,
+          "markdownDescription": "Turn on usage of the statusBar integration.\n\nNote: You need to ensure you are adding something like `%{coc#status()}` in order to dispaly it."
         },
         "metals.treeviews.initialWidth": {
           "type": "number",
@@ -285,7 +286,7 @@
   },
   "dependencies": {
     "coc.nvim": "0.0.75",
-    "metals-languageclient": "0.1.19",
+    "metals-languageclient": "0.1.20",
     "promisify-child-process": "^3.1.3",
     "vscode-languageserver-protocol": "3.15.0-next.6"
   },

--- a/package.json
+++ b/package.json
@@ -113,6 +113,10 @@
           },
           "markdownDescription": "Optional list of custom resolvers passed to Coursier when fetching metals dependencies.\n\nFor documentation on accepted values see the [Coursier documentation](https://get-coursier.io/docs/other-repositories).\n\nThe extension will pass these to Coursier using the COURSIER_REPOSITORIES environment variable after joining the custom repositories with a pipe character (|)."
         },
+        "metals.statusBarEnabled": {
+          "type": "boolean",
+          "default": true
+        },
         "metals.treeviews.initialWidth": {
           "type": "number",
           "default": 40,

--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -15,6 +15,16 @@ export interface DoctorProvider {}
 export interface StatusBarProvider {}
 
 export class MetalsFeatures implements StaticFeature {
+  private statusBarEnabled: boolean;
+
+  constructor(statusBarEnabled: boolean | undefined) {
+    if (statusBarEnabled !== undefined) {
+      this.statusBarEnabled = statusBarEnabled;
+    } else {
+      this.statusBarEnabled = false;
+    }
+  }
+
   debuggingProvider?: DebuggingProvider;
   decorationProvider?: DecorationProvider;
   quickPickProvider?: QuickPickProvider;

--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -49,8 +49,10 @@ export class MetalsFeatures implements StaticFeature {
     (params.capabilities
       .experimental as any).executeClientCommandProvider = true;
     (params.capabilities.experimental as any).doctorProvider = "json";
-    (params.capabilities.experimental as any).statusBarProvider =
-      "show-message";
+    (params.capabilities.experimental as any).statusBarProvider = this
+      .statusBarEnabled
+      ? "on"
+      : "show-message";
   }
   fillClientCapabilities(): void {}
   initialize(capabilities: ServerCapabilities): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,6 +219,7 @@ function launchMetals(
     progress.isProgress = false;
     progress.text = "Metals is Ready!";
     progress.show();
+
     const commands = [
       "build-import",
       "build-connect",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,8 @@ import {
   MetalsQuickPick,
   DecorationsRangesDidChange,
   PublishDecorationsParams,
-  MetalsQuickPickParams
+  MetalsQuickPickParams,
+  MetalsStatus
 } from "./metalsProtocol";
 import {
   checkServerVersion,
@@ -33,7 +34,8 @@ import {
   RevealOutputChannelOn,
   workspace,
   events,
-  FloatFactory
+  FloatFactory,
+  StatusBarItem
 } from "coc.nvim";
 import {
   ExecuteCommandRequest,
@@ -46,6 +48,7 @@ import { TreeViewController } from "./tvp/controller";
 import { TreeViewFeature } from "./tvp/feature";
 import { TreeViewsManager } from "./tvp/treeviews";
 import * as path from "path";
+import WannaBeStatusBarItem from "./WannaBeStatusBarItem";
 
 export async function activate(context: ExtensionContext) {
   detectLaunchConfigurationChanges();
@@ -103,9 +106,23 @@ function fetchAndLaunchMetals(context: ExtensionContext, javaHome: string) {
     javaConfig
   });
 
-  trackDownloadProgress(fetchProcess).then(
+  const statusBarEnabled = config.get<boolean>("statusBarEnabled");
+
+  const progress: StatusBarItem = statusBarEnabled
+    ? workspace.createStatusBarItem(0, { progress: true })
+    : new WannaBeStatusBarItem(0, true, "Preparing Metals");
+
+  const title = `Downloading Metals v${serverVersion}`;
+  trackDownloadProgress(title, fetchProcess, progress).then(
     classpath => {
-      launchMetals(context, classpath, serverProperties, javaConfig);
+      launchMetals(
+        context,
+        classpath,
+        serverProperties,
+        javaConfig,
+        progress,
+        statusBarEnabled
+      );
     },
     () => {
       const msg = (() => {
@@ -138,7 +155,9 @@ function launchMetals(
   context: ExtensionContext,
   metalsClasspath: string,
   serverProperties: string[],
-  javaConfig: JavaConfig
+  javaConfig: JavaConfig,
+  progress: StatusBarItem,
+  statusBarEnabled: boolean | undefined
 ) {
   const serverOptions = getServerOptions({
     metalsClasspath,
@@ -162,7 +181,7 @@ function launchMetals(
     clientOptions
   );
 
-  const features = new MetalsFeatures();
+  const features = new MetalsFeatures(statusBarEnabled);
   const treeViewFeature = new TreeViewFeature(client);
   client.registerFeature(features);
   client.registerFeature(treeViewFeature);
@@ -175,8 +194,8 @@ function launchMetals(
     100,
     true
   );
-  const decorationProvider = new DecorationProvider(floatFactory);
 
+  const decorationProvider = new DecorationProvider(floatFactory);
   const treeViewsManager = new TreeViewsManager(workspace.nvim, context.logger);
   const treeViewController = new TreeViewController(
     treeViewFeature,
@@ -197,8 +216,9 @@ function launchMetals(
   context.subscriptions.push(client.start());
 
   client.onReady().then(_ => {
-    workspace.showMessage("Metals is ready!");
-
+    progress.isProgress = false;
+    progress.text = "Metals is Ready!";
+    progress.show();
     const commands = [
       "build-import",
       "build-connect",
@@ -317,6 +337,18 @@ function launchMetals(
           }
         })
     );
+
+    if (statusBarEnabled) {
+      const statusItem = workspace.createStatusBarItem(0);
+      client.onNotification(MetalsStatus.type, params => {
+        statusItem.text = params.text;
+        if (params.show) {
+          statusItem.show();
+        } else if (params.hide) {
+          statusItem.hide();
+        }
+      });
+    }
 
     if (features.decorationProvider) {
       client.onNotification(

--- a/src/metalsProtocol.ts
+++ b/src/metalsProtocol.ts
@@ -90,3 +90,17 @@ export interface MetalsQuickPickItem {
   detail?: string;
   alwaysShow?: boolean;
 }
+
+export namespace MetalsStatus {
+  export const type = new NotificationType<MetalsStatusParams, void>(
+    "metals/status"
+  );
+}
+
+export interface MetalsStatusParams {
+  text: string;
+  show?: boolean;
+  hide?: boolean;
+  tooltip?: string;
+  command?: string;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,6 +79,7 @@ export function detectLaunchConfigurationChanges(): void {
             workspace.nvim.command(Commands.RESTART_COC, true);
           }
         });
-    }
+    },
+    ["statusBarEnabled"]
   );
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,18 +1,21 @@
 import { Commands } from "./commands";
 
-import { workspace } from "coc.nvim";
+import { workspace, StatusBarItem } from "coc.nvim";
 import { ChildProcessPromise } from "promisify-child-process";
-import ProgressItem from "./ProgressItem";
 import { downloadProgress } from "metals-languageclient";
 import * as metalsLanguageClient from "metals-languageclient";
 
 export function trackDownloadProgress(
-  download: ChildProcessPromise
+  title: string,
+  download: ChildProcessPromise,
+  progress: StatusBarItem
 ): Promise<string> {
-  const progress = new ProgressItem().createStatusBarItem("Preparing Metals");
   return downloadProgress({
     download,
-    onProgress: progress.update,
+    onProgress: _ => {
+      progress.text = title;
+      progress.show();
+    },
     onError: progress.dispose,
     onComplete: progress.dispose
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3280,10 +3280,10 @@ merge2@^1.2.3:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
   integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
 
-metals-languageclient@0.1.19:
-  version "0.1.19"
-  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.1.19.tgz#6eaae47103c438aec86d24e16e585c434e2d6829"
-  integrity sha512-1dWW9OLwUUSfVSHjDpsMUkuNp6dQuaBgRPJGV90Bq+6TGmZOHYK07RdCQFXCQh0Wk3HBWlTdc5wPl/Q9O3kZPw==
+metals-languageclient@0.1.20:
+  version "0.1.20"
+  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.1.20.tgz#a199888b44d16ddea9083c7a002d9a9753b2736b"
+  integrity sha512-Ok3/i1ckdd7b3K+PM9dsK21kRwXrAlfpZrXV5tgAo8I+QWSQTPa0E5uciNT/wOCKgCaRuC7Zu0vmYgLA4hbOiQ==
   dependencies:
     fp-ts "^2.4.1"
     locate-java-home "^1.1.2"


### PR DESCRIPTION
This pr introduces a setting that will allows the user to turn on a status bar integration that will utilize the `metals/status` rather than the `showMessage` that it currently uses. Part of me just wants to only support it and not even bother with the `WannaBeStatusBarItem` that is really just a message. It would simplify the logic and cut out a configuration. However, if I do that, existing users will have to manually add in a either a status line plugin or add in something similar to what I use like what I have below. If not, they won't bee seeing any messages from Metals.

```vim
  function! CocMinimalStatus() abort
    return get(g:, 'coc_status', '')
  endfunction

  let g:airline_section_c = '%t %#LineNr#%{CocMinimalStatus()}'
```
Even though I do use a status bar plugin, I still need this in order for it to show correctly, but with others you won't need to.

Thoughts on whether this should be introduced as a configuration setting or if I should just defaul to it being on and force users to add something like this to their `vimrc`?

@olafurpg I feel like you always have good thoughts on this sort of thing.
