### PR TITLE
Fix typo on README (metails)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -231,7 +231,7 @@ members, and methods are all color coded.
   - `metals.restartServer`
   - `metals.build-import`
   - `metals.build-connect`
-  - `metails.build-restart`
+  - `metals.build-restart`
   - `metals.sources-scan`
   - `metals.compile-cascade`
   - `metals.compile-cancel`


### PR DESCRIPTION
This PR fixes a small typo on the README file, showing `metails` instead of `metals`.