### PR TITLE
add in missing gradle and maven settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "onLanguage:scala",
     "workspaceContains:build.sbt",
     "workspaceContains:build.sc",
+    "workspaceContains:build.gradle",
+    "workspaceContains:pom.xml",
     "workspaceContains:project/build.properties",
     "workspaceContains:**/scala/**"
   ],


### PR DESCRIPTION
This pr adds in the missing `activationEvents` for both gradle and maven.

Closes #138 