### PR TITLE
Remove unecessary async method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ import WannaBeStatusBarItem from "./WannaBeStatusBarItem";
 
 export async function activate(context: ExtensionContext) {
   detectLaunchConfigurationChanges();
-  await checkServerVersion();
+  checkServerVersion();
 
   getJavaHome(workspace.getConfiguration("metals").get("javaHome")).then(
     (javaHome) => fetchAndLaunchMetals(context, javaHome),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,7 +21,7 @@ export function trackDownloadProgress(
   });
 }
 
-export async function checkServerVersion() {
+export function checkServerVersion() {
   const config = workspace.getConfiguration("metals");
   metalsLanguageClient.checkServerVersion({
     config,


### PR DESCRIPTION
Having some issues with this method in vim. Firstly, it doesn't need to be async since it's returning void.