### PR TITLE
remove resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -306,11 +306,8 @@
   },
   "dependencies": {
     "coc.nvim": "0.0.77",
-    "metals-languageclient": "0.1.22",
+    "metals-languageclient": "0.1.23",
     "promisify-child-process": "3.1.4",
     "vscode-languageserver-protocol": "3.15.3"
-  },
-  "resolutions": {
-    "vscode-jsonrpc": "^5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3280,10 +3280,10 @@ merge2@^1.2.3:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
   integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
 
-metals-languageclient@0.1.22:
-  version "0.1.22"
-  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.1.22.tgz#dd5deb6c74b9f26c16b868d1f35b64e32be02979"
-  integrity sha512-IxrgkGE5Naip8evXrL9flBOTyBkIqXtePetdUIzbiuT7pk5W11n97iJvNPPBYUP5N5VtpQq8+VU2+7Gl4/TUZg==
+metals-languageclient@0.1.23:
+  version "0.1.23"
+  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.1.23.tgz#950cc13734a72bfbcd0c091f7fbf66a14e60c3b3"
+  integrity sha512-Gi/qomdchfurnRIiEH8RjLbYZ926zJDE/acOx8xCtAx7Ai9vA49ZyJnh/BP0BNqe8VXVvPHmadmqdM+4lC7hLQ==
   dependencies:
     fp-ts "^2.4.1"
     locate-java-home "^1.1.2"
@@ -3292,7 +3292,7 @@ metals-languageclient@0.1.22:
     promisify-child-process "^3.1.3"
     semver "^7.1.1"
     shell-quote "^1.7.2"
-    vscode-languageserver-protocol "3.15.0-next.6"
+    vscode-languageserver-protocol "3.15.3"
 
 micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
@@ -5579,18 +5579,10 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-vscode-jsonrpc@^4.1.0-next.2, vscode-jsonrpc@^5, vscode-jsonrpc@^5.0.1:
+vscode-jsonrpc@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
   integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
-
-vscode-languageserver-protocol@3.15.0-next.6:
-  version "3.15.0-next.6"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.6.tgz#a8aeb7e7dd65da8216b386db59494cdfd3215d92"
-  integrity sha512-/yDpYlWyNs26mM23mT73xmOFsh1iRfgZfBdHmfAxwDKwpQKLoOSqVidtYfxlK/pD3IEKGcAVnT4WXTsguxxAMQ==
-  dependencies:
-    vscode-jsonrpc "^4.1.0-next.2"
-    vscode-languageserver-types "^3.15.0-next.2"
 
 vscode-languageserver-protocol@3.15.3, vscode-languageserver-protocol@^3.15.3:
   version "3.15.3"
@@ -5600,7 +5592,7 @@ vscode-languageserver-protocol@3.15.3, vscode-languageserver-protocol@^3.15.3:
     vscode-jsonrpc "^5.0.1"
     vscode-languageserver-types "3.15.1"
 
-vscode-languageserver-types@3.15.1, vscode-languageserver-types@^3.15.0-next.2, vscode-languageserver-types@^3.15.1:
+vscode-languageserver-types@3.15.1, vscode-languageserver-types@^3.15.1:
   version "3.15.1"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
   integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==


### PR DESCRIPTION
This updates the metals-languageserver dependency which allows us to remove `resolutions`. This closes #150 since now the `npm install` won't fail if someone does an install with `:CocInstall <url>`.