### PR TITLE
Make sure to commit in release to add new version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Set new version
         run: yarn version --no-git-tag-version --new-version ${{ steps.get_version.outputs.NEW_VERSION }}
 
+      - name: Commit changes
+        run: |
+          git add .
+          git commit -m "v${{ steps.get_version.outputs.NEW_VERSION }}"
+
       - name: Push changes
         run: git push origin HEAD:master
 


### PR DESCRIPTION
I wasn't actually committing the new version before pushing back to github in ci causing the version to not be set. This fixes that.

Closes #145