### PR TITLE
change the way we target the window id on go-to for tree views

### DIFF
--- a/src/tvp/treeviews.ts
+++ b/src/tvp/treeviews.ts
@@ -337,8 +337,12 @@ export class TreeViewsManager implements Disposable {
         allViewNames.split(",").map((viewName) => tabpage.getVar(viewName))
       );
       const windows = await tabpage.windows;
-      const mbWindow = windows.find(
-        (window) => allTreeViews.find((wId) => window.id === wId) === undefined
+      // Sort this to ensure we find the first opened to avoid opening in NERDTree
+      const windowIds = windows.map((window) => window.id).sort();
+      const mbWindow = windowIds.find(
+        (windowId) =>
+          allTreeViews.find((treeViewId) => windowId === treeViewId) ===
+          undefined
       );
       if (mbWindow === undefined) {
         const initWidth = this.config.get<number>("initialWidth")!;
@@ -356,7 +360,7 @@ export class TreeViewsManager implements Disposable {
           await this.nvim.command(`silent ${position} vertical new`);
         }
       } else {
-        await this.nvim.call("win_gotoid", mbWindow.id);
+        await this.nvim.call("win_gotoid", mbWindow);
         if (windowProp === WindowProp.HSplit) {
           await this.nvim.command("split");
         } else if (windowProp === WindowProp.VSplit) {


### PR DESCRIPTION
This is a bit of a hack to change the way we grab the window id before we reveal what the go-to is requesting. Before we were just grabbing the first one that wasn't a tree view related window. However this would often result in it opening in the NERDTree window. I changed the logic to look at the window ids, sort them, an then find the first. This _should_ grab the earliest created one, which AFAIK shouldn't ever be NERDTree's window. I did it this way to avoid having to do NERDTree specific things in the logic.

Closes #169

Also an ongoing effort to just improve the TVP integration in #170 