### PR TITLE
Add node 14 into node-version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        node-version: [10, 12, 13]
+        node-version: [10, 12, 13, 14]
 
     env:
       NODE_ENV: test


### PR DESCRIPTION
Locally it seems that there is no issue with Node 14, but adding it into the node-version matrix to ensure on different os's.

Addresses #201 