### PR TITLE
Remove check against clientCapabilities

### DIFF
--- a/src/tvp/feature.ts
+++ b/src/tvp/feature.ts
@@ -22,7 +22,6 @@ import {
   Position,
   RequestType,
   RPCMessageType,
-  ServerCapabilities,
   TextDocument,
   TextDocumentPositionParams,
 } from "vscode-languageserver-protocol";
@@ -45,8 +44,7 @@ export class TreeViewFeature implements DynamicFeature<void> {
 
   public fillClientCapabilities(): void {}
 
-  public initialize(capabilities: ServerCapabilities): void {
-    if (!capabilities.experimental!.treeViewProvider) return;
+  public initialize(): void {
     const client = this._client;
 
     client.onNotification(MetalsTreeViewDidChange.type, (params) => {


### PR DESCRIPTION
Since we now no longer declare experimentalCapabilities in Metals
and we are fully going the initializationOptions route, this should
also be reflected here or users are going to get issues with the
latest metals snapshot.