### PR TITLE
Switch toggleLogs to use workspace.showOutput.

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -25,5 +25,5 @@ export namespace Commands {
   /**
    * Shows Coc Info and logs
    */
-  export const OPEN_LOGS = "CocInfo";
+  export const OPEN_LOGS = "CocCommand workspace.showOutput";
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,11 +50,11 @@ export function checkServerVersion(config: WorkspaceConfiguration) {
 }
 
 export function toggleLogs() {
-  const infoBuffer = workspace.documents.find((doc) =>
-    doc.uri.endsWith("info")
+  const logsBuffer = workspace.documents.find(
+    (doc) => doc.uri == "output:/metals"
   );
-  if (infoBuffer) {
-    workspace.nvim.command(`bd ${infoBuffer.bufnr}`);
+  if (logsBuffer) {
+    workspace.nvim.command(`bd ${logsBuffer.bufnr}`);
   } else {
     workspace.nvim.command(Commands.OPEN_LOGS);
   }


### PR DESCRIPTION
Previously we used CocInfo which worked, but wasn't as polished
as the workspace.showOutput for actually showing the logs. This
will allow for a better trouble-shooting experience