### PR TITLE
Add in extensions and commands from metals-languageclient.

### DIFF
--- a/package.json
+++ b/package.json
@@ -355,7 +355,7 @@
   },
   "dependencies": {
     "coc.nvim": "0.0.77",
-    "metals-languageclient": "0.2.8",
+    "metals-languageclient": "0.3.0",
     "promisify-child-process": "4.1.1",
     "vscode-languageserver-protocol": "3.15.3"
   }

--- a/src/DebuggingFeature.ts
+++ b/src/DebuggingFeature.ts
@@ -4,6 +4,7 @@ import {
   ExecuteCommandRequest,
 } from "vscode-languageserver-protocol";
 import { commands } from "coc.nvim";
+import { ClientCommands, ServerCommands } from "metals-languageclient";
 
 interface DebugAdapterStartResponse {
   name: string;
@@ -20,7 +21,7 @@ export class DebuggingFeature implements StaticFeature {
   public initialize(): void {
     const debugHandler = async (_: boolean, ...args: any[]) => {
       let params: ExecuteCommandParams = {
-        command: "debug-adapter-start",
+        command: ServerCommands.DebugAdapterStart,
         arguments: args,
       };
       return this._client.sendRequest(ExecuteCommandRequest.type, params).then(
@@ -40,13 +41,13 @@ export class DebuggingFeature implements StaticFeature {
     };
 
     commands.registerCommand(
-      "metals-run-session-start",
+      ClientCommands.StartRunSession,
       debugHandler.bind(this, false),
       null,
       true
     );
     commands.registerCommand(
-      "metals-debug-session-start",
+      ClientCommands.StartDebugSession,
       debugHandler.bind(this, true),
       null,
       true

--- a/src/metalsProtocol.ts
+++ b/src/metalsProtocol.ts
@@ -1,48 +1,10 @@
-import {
-  ExecuteCommandParams,
-  NotificationType,
-  RequestType,
-} from "vscode-languageserver-protocol";
-import { DecorationOptions, InputBoxOptions } from "./portedProtocol";
+import { NotificationType } from "vscode-languageserver-protocol";
+import { DecorationOptions } from "./portedProtocol";
 
-export namespace ExecuteClientCommand {
-  export const type = new NotificationType<ExecuteCommandParams, void>(
-    "metals/executeClientCommand"
-  );
-}
-
-export namespace MetalsInputBox {
-  export const type = new RequestType<
-    InputBoxOptions,
-    MetalsInputBoxResult,
-    void,
-    void
-  >("metals/inputBox");
-}
-
-export interface MetalsSlowTaskParams {
-  message: string;
-  quietLogs?: boolean;
-  secondsElapsed?: number;
-}
-
-export interface MetalsSlowTaskResult {
-  cancel: boolean;
-}
-
-export interface MetalsStatusParams {
-  text: string;
-  show?: boolean;
-  hide?: boolean;
-  tooltip?: string;
-  command?: string;
-}
-
-export interface MetalsInputBoxResult {
-  value?: string;
-  cancelled?: boolean;
-}
-
+/**
+ * As much as I'd like to move the decoration protocol over to the shared
+ * library it's too intertwined with VS Code.
+ */
 export interface PublishDecorationsParams {
   uri: string;
   options: DecorationOptions[];
@@ -52,54 +14,4 @@ export namespace DecorationsRangesDidChange {
   export const type = new NotificationType<PublishDecorationsParams, void>(
     "metals/publishDecorations"
   );
-}
-
-export namespace MetalsDidFocus {
-  export const type = new NotificationType<string, void>(
-    "metals/didFocusTextDocument"
-  );
-}
-
-export namespace MetalsQuickPick {
-  export const type = new RequestType<
-    MetalsQuickPickParams,
-    MetalsQuickPickResult,
-    void,
-    void
-  >("metals/quickPick");
-}
-
-export interface MetalsQuickPickParams {
-  items: MetalsQuickPickItem[];
-  matchOnDescription?: boolean;
-  matchOnDetail?: boolean;
-  placeHolder?: string;
-  ignoreFocusOut?: boolean;
-}
-
-export interface MetalsQuickPickResult {
-  itemId?: string;
-  cancelled?: boolean;
-}
-
-export interface MetalsQuickPickItem {
-  id: string;
-  label: string;
-  description?: string;
-  detail?: string;
-  alwaysShow?: boolean;
-}
-
-export namespace MetalsStatus {
-  export const type = new NotificationType<MetalsStatusParams, void>(
-    "metals/status"
-  );
-}
-
-export interface MetalsStatusParams {
-  text: string;
-  show?: boolean;
-  hide?: boolean;
-  tooltip?: string;
-  command?: string;
 }

--- a/src/portedProtocol.ts
+++ b/src/portedProtocol.ts
@@ -8,47 +8,6 @@ import { Range, MarkupContent } from "vscode-languageserver-protocol";
  * Keep in mind that some may not be fully implemented here in the same way.
  */
 
-export interface InputBoxOptions {
-  /** * The value to prefill in the input box.  */
-  value?: string;
-  /** * Selection of the prefilled [`value`](#InputBoxOptions.value). Defined as tuple of two number where the * first is the inclusive start index and the second the exclusive end index. When `undefined` the whole * word will be selected, when empty (start equals end) only the cursor will be set, * otherwise the defined range will be selected.  */ valueSelection?: [
-    number,
-    number
-  ];
-
-  /**
-   * The text to display underneath the input box.
-   */
-  prompt?: string;
-
-  /**
-   * An optional string to show as place holder in the input box to guide the user what to type.
-   */
-  placeHolder?: string;
-
-  /**
-   * Set to `true` to show a password prompt that will not show the typed value.
-   */
-  password?: boolean;
-
-  /**
-   * Set to `true` to keep the input box open when focus moves to another part of the editor or to another window.
-   */
-  ignoreFocusOut?: boolean;
-
-  /**
-   * An optional function that will be called to validate input and to give a hint
-   * to the user.
-   *
-   * @param value The current value of the input box.
-   * @return A human readable string which is presented as diagnostic message.
-   * Return `undefined`, `null`, or the empty string when 'value' is valid.
-   */
-  validateInput?(
-    value: string
-  ): string | undefined | null | Thenable<string | undefined | null>;
-}
-
 /**
  * Represents options for a specific decoration in a [decoration set](#TextEditorDecorationType).
  */

--- a/src/tvp/feature.ts
+++ b/src/tvp/feature.ts
@@ -13,6 +13,7 @@ import {
   MetalsTreeViewNodeCollapseDidChange,
   MetalsTreeViewReveal,
   MetalsTreeViewVisibilityDidChange,
+  ServerCommands,
 } from "metals-languageclient";
 import {
   Disposable,
@@ -117,10 +118,10 @@ export class TreeViewFeature implements DynamicFeature<void> {
     });
 
     this.mbGotoCommandDisposable = commands.registerCommand(
-      "metals.goto",
+      `metals.${ServerCommands.Goto}`,
       async (...args: any[]) => {
         let params: ExecuteCommandParams = {
-          command: "metals.goto",
+          command: ServerCommands.Goto,
           arguments: args,
         };
         return client

--- a/yarn.lock
+++ b/yarn.lock
@@ -3280,10 +3280,10 @@ merge2@^1.2.3:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
   integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
 
-metals-languageclient@0.2.8:
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.2.8.tgz#82687c65bc386a50c6c3dfc2d1c7192629f98527"
-  integrity sha512-RGy28w9iYwGt3im5Da6YjD9eF6GTKtrRvluWy8StfwbHvI/KsobF1zmyVX/fD0wvNUCY0am867rImkjs1paTzA==
+metals-languageclient@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.3.0.tgz#87589fc1788f4929851910e2128e09ed40c767d5"
+  integrity sha512-Uh3jj6+b/vWdR3k1BqC8QZK3a/5Z9mVdI+OhVbFGMq6slJ6odFLTDaDZ25zpon4MaLEs+IIC4R91pJcmFdU6og==
   dependencies:
     fp-ts "^2.4.1"
     locate-java-home "^1.1.2"


### PR DESCRIPTION
This implements the changes made in https://github.com/scalameta/metals-languageclient/pull/163 to reduce the amount of shared boilerplate between this and the vs code extension.