### PR TITLE
Account for new lines in doctor header.

### DIFF
--- a/src/embeddedDoctor.ts
+++ b/src/embeddedDoctor.ts
@@ -29,7 +29,7 @@ export function makeVimDoctor(doctorResult: DoctorResult): void {
     const doctor: string[] = [
       doctorResult.title,
       "-------------",
-      doctorResult.headerText,
+      ...doctorResult.headerText.split("\n"),
       "",
       Object.keys(doctorResult.targets[0])
         .map((heading: string, index: number) => padText(heading, index))


### PR DESCRIPTION
Previously there was nevermore than one message in the header coming from
Doctor. Since now there can be, we simply account for them and split on the
newline to create a nicer display.

Closes #248