### PR TITLE
Remove isCompletionItemResolve setting.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,6 @@ async function launchMetals(
   const initializationOptions: MetalsInitializationOptions = {
     compilerOptions: {
       completionCommand: "editor.action.triggerSuggest",
-      isCompletionItemResolve: false,
       overrideDefFormat: "unicode",
       parameterHintsCommand: "editor.action.triggerParameterHints",
     },


### PR DESCRIPTION
Without even realizing it, having this in here had been causing
Metals to declare that it wasn't a completionResolve provider
when it reality it was. The reason it wasn't was because I was
telling it to be initialized with the presentation compiler flag
to not provide documentation. I'm assuming this has been in here since
the start, and it was a total oversight that it wasn't removed.

Closes #188