### PR TITLE
Remove setting the client since it's no longer necessary

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -175,7 +175,6 @@ async function launchMetals(
     metalsClasspath,
     serverProperties,
     javaConfig,
-    clientName: "coc-metals",
   });
 
   const initializationOptions: MetalsInitializationOptions = {


### PR DESCRIPTION
Now that everything is fully set via `initializationOptions`, we no longer need to rely on setting the client.