### PR TITLE
Add in settings to show implicits and inferred types in hovers.

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,6 +248,14 @@
           "type": "string",
           "default": "t",
           "description": "Execute command and open node under cursor in tab (if node is class, trait and so on)"
+        },
+        "metals.typeAnnotationsEnabled": {
+          "type": "boolean",
+          "description": "When this option is enabled, each method that has infered types have those types displayed as extra info in the hover window."
+        },
+        "metals.implicitArgumentAnnotationsEnabled": {
+          "type": "boolean",
+          "description": "When this option is enabled, each method that has implicit arguments have those aruments displayed as extra info in the hover window."
         }
       }
     },


### PR DESCRIPTION
This corresponds to https://github.com/scalameta/metals/pull/2103