### PR TITLE
Remove showMessage after command execution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -274,7 +274,6 @@ async function launchMetals(
 
     commands.forEach((command) => {
       registerCommand("metals." + command, async () => {
-        workspace.showMessage("metals" + command);
         client.sendRequest(ExecuteCommandRequest.type, { command });
       });
     });


### PR DESCRIPTION
This has bugged me for a long time, and I totally didn't realize I even had this in here. I'm removing it mainly because there is no point to show the message after you execute the command. For example if you trigger a `metals.run-doctor`, this would just show `metalsrun-doctor`. I was going to just correct the spacing, but again, I don't feel it's necessary to even have it.