### PR TITLE
Adds statusline text when Metals is idle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -469,12 +469,12 @@ async function launchMetals(
     if (statusBarEnabled) {
       const statusItem = workspace.createStatusBarItem(0);
       client.onNotification(MetalsStatus.type, (params) => {
-        statusItem.text = params.text;
         if (params.show) {
-          statusItem.show();
+          statusItem.text = params.text;
         } else if (params.hide) {
-          statusItem.hide();
+          statusItem.text = "Metals";
         }
+        statusItem.show();
       });
     }
 


### PR DESCRIPTION
This PR solves #376.

Not really sure if you're ok with this solution: the `params.hide` flag suggests something different than what this implementation does. However, it seems to work well: I've tested it by opening a Scala project and having it rebuild a couple of times. Between these activities, the text 'Metals' shows up nicely. Maybe we should re-name the flag to `idle` or something to that effect.