### PR TITLE
Add valid entry to engines field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "bugs": "https://github.com/scalameta/coc-metals/issues",
   "license": "Apache-2.0",
   "engines": {
-    "coc": "^0.0.78"
+    "node": ">= 12.12"
   },
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Fixes this warning when running `yarn install`.

```
warning coc-metals@1.0.7: The engine "coc" appears to be invalid.
```

Unfortuantely `coc` isn't a valid value for `engines` in `package.json`.
See: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#engines

According to the README for coc.vim (as of this writing) it requires
12.12 or above.  See: https://github.com/neoclide/coc.nvim#quick-start
