### PR TITLE
Update `TextDocument` import statements

### DIFF
--- a/src/tvp/feature.ts
+++ b/src/tvp/feature.ts
@@ -23,9 +23,10 @@ import {
   Position,
   RequestType,
   RPCMessageType,
-  TextDocument,
   TextDocumentPositionParams,
 } from "vscode-languageserver-protocol";
+import { TextDocument } from "vscode-languageserver-textdocument";
+
 import { TreeViewProvider } from "./provider";
 
 export class TreeViewFeature implements DynamicFeature<void> {

--- a/src/tvp/model.ts
+++ b/src/tvp/model.ts
@@ -1,6 +1,7 @@
 import { MetalsTreeViewNode } from "metals-languageclient";
 import { Disposable, Emitter } from "vscode-jsonrpc";
-import { Position, TextDocument } from "vscode-languageserver-types";
+import { Position } from "vscode-languageserver-types";
+import { TextDocument } from "vscode-languageserver-textdocument";
 import { TreeViewProvider } from "./provider";
 import { groupBy } from "./utils";
 

--- a/src/tvp/provider.ts
+++ b/src/tvp/provider.ts
@@ -3,7 +3,8 @@ import {
   MetalsTreeViewNode,
 } from "metals-languageclient";
 import { Event } from "vscode-jsonrpc";
-import { Position, TextDocument } from "vscode-languageserver-protocol";
+import { Position } from "vscode-languageserver-protocol";
+import { TextDocument } from "vscode-languageserver-textdocument";
 
 export interface TreeViewProvider {
   viewId: string;

--- a/src/tvp/treeview.ts
+++ b/src/tvp/treeview.ts
@@ -6,7 +6,8 @@ import {
   WorkspaceConfiguration,
 } from "coc.nvim";
 import * as log4js from "log4js";
-import { Position, TextDocument } from "vscode-languageserver-types";
+import { Position } from "vscode-languageserver-types";
+import { TextDocument } from "vscode-languageserver-textdocument";
 import { Node, NodeView, TreeModel, TreeModelUpdate } from "./model";
 import { sequence } from "./utils";
 

--- a/src/tvp/treeviews.ts
+++ b/src/tvp/treeviews.ts
@@ -1,7 +1,8 @@
 import { NeovimClient as Neovim, Tabpage, Window } from "@chemzqm/neovim";
 import { Disposable, workspace, WorkspaceConfiguration } from "coc.nvim";
 import * as log4js from "log4js";
-import { Position, TextDocument } from "vscode-languageserver-types";
+import { Position } from "vscode-languageserver-types";
+import { TextDocument } from "vscode-languageserver-textdocument";
 import { TreeModel } from "./model";
 import { TreeView, TreeViewDescription } from "./treeview";
 import { sequence } from "./utils";


### PR DESCRIPTION
Warning from tsserver:

```
[tsserver 6385] [I] 'TextDocument' is deprecated
```

If you take a look at the actual `@deprecated` jsdocs it asks you to
"Use the text document from the new vscode-languageserver-textdocument
package."
