### PR TITLE
Clarify the usage of metals.javaHome

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export async function activate(context: ExtensionContext) {
       () => {
         const message =
           "Unable to find a Java 8 or Java 11 installation on this computer. " +
-          "To fix this problem, update the 'Java Home' setting to point to a Java 8 or Java 11 home directory";
+          "To fix this problem, update the 'metals.javaHome' setting to point to a Java 8 or Java 11 home directory";
         const openSettings = "Open Settings";
         const ignore = "Ignore for now";
         workspace


### PR DESCRIPTION
On the main metals repo we've gotten it reported a couple times that the
message about setting java home incorrectly sounds like you should set
the `java.home` setting, which isn't used by the Metals extensions, but
rather the `metals.javaHome` is. This just clarifies that and is a
follow-up to the same thing done in the VS Code extension. https://github.com/scalameta/metals-vscode/pull/644