### PR TITLE
Fix has_preview exeption

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -21,7 +21,7 @@ export namespace Commands {
   /**
    * Returns the result of checking to see if a current preview window exists
    */
-  export const HAS_PREVIEW = "coc#util#has_preview";
+  export const HAS_PREVIEW = "coc#list#has_preview";
   /**
    * Shows Coc Info and logs
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -408,7 +408,7 @@ async function launchMetals(
           makeVimDoctor(JSON.parse(doctorJson));
           break;
         case ClientCommands.ReloadDoctor:
-          workspace.nvim.call("coc#util#has_preview").then((preview) => {
+          workspace.nvim.call("coc#list#has_preview").then((preview) => {
             if (preview > 0) {
               const doctorJson: string =
                 params.arguments && params.arguments[0];

--- a/src/index.ts
+++ b/src/index.ts
@@ -408,7 +408,7 @@ async function launchMetals(
           makeVimDoctor(JSON.parse(doctorJson));
           break;
         case ClientCommands.ReloadDoctor:
-          workspace.nvim.call("coc#list#has_preview").then((preview) => {
+          workspace.nvim.call(Commands.HAS_PREVIEW).then((preview) => {
             if (preview > 0) {
               const doctorJson: string =
                 params.arguments && params.arguments[0];


### PR DESCRIPTION
I checked the signature of the removed function and I think `coc#list#has_preview` does the same.

https://github.com/neoclide/coc.nvim/commit/00ed6677383e56d79cb2812bfe954f424bb15ded#diff-600a800688b494cf9156b1d447016c253461ad3e3553ae6b9e52b31453e792deL22
```vim
function! coc#util#has_preview()
  for i in range(1, winnr('$'))
    if getwinvar(i, '&previewwindow')
      return i
    endif
  endfor
  return 0
endfunction
``` 

https://github.com/neoclide/coc.nvim/blob/e231666bcb532fac61ba50dd69e3b31477f43982/autoload/coc/list.vim#L102
```vim
" Check if previewwindow exists on current tab.
function! coc#list#has_preview()
  for i in range(1, winnr('$'))
    let preview = getwinvar(i, 'previewwindow', getwinvar(i, '&previewwindow', 0))
    if preview
      return i
    endif
  endfor
  return 0
endfunction
```

Solves #421 