### PR TITLE
Remove no longer existing jumpTo function.

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -26,4 +26,8 @@ export namespace Commands {
    * Shows Coc Info and logs
    */
   export const OPEN_LOGS = "CocCommand workspace.showOutput";
+  /**
+   * Move the cursor to the specified position
+   */
+  export const MOVE_TO = "coc#cursor#move_to";
 }

--- a/src/tvp/treeview.ts
+++ b/src/tvp/treeview.ts
@@ -10,6 +10,7 @@ import { Position } from "vscode-languageserver-types";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { Node, NodeView, TreeModel, TreeModelUpdate } from "./model";
 import { sequence } from "./utils";
+import { Commands } from "../commands";
 
 export interface TreeViewDescription {
   name: string;
@@ -122,7 +123,7 @@ export class TreeView implements Disposable {
           this.model.revealByParents(parents.concat(""))
         )
       );
-      await this.nvim.call("coc#util#jumpTo", [0, 1]);
+      await this.nvim.call(Commands.MOVE_TO, [0, 1]);
     }
   }
 
@@ -304,7 +305,7 @@ export class TreeView implements Disposable {
     if (parent === undefined) return;
     const offset = await this.model.findNodeOffset(parent.makeView());
     if (offset === undefined) return;
-    await this.nvim.call("coc#util#jumpTo", [offset - 1, 1]);
+    await this.nvim.call(Commands.MOVE_TO, [offset - 1, 1]);
   }
 
   public async gotoEdgeNode(first: boolean): Promise<void> {
@@ -317,7 +318,7 @@ export class TreeView implements Disposable {
       const node = first ? children[0] : children[children.length - 1];
       const offset = await this.model.findNodeOffset(node.makeView());
       if (offset === undefined) return;
-      await this.nvim.call("coc#util#jumpTo", [offset - 1, 1]);
+      await this.nvim.call(Commands.MOVE_TO, [offset - 1, 1]);
     }
   }
 
@@ -341,7 +342,7 @@ export class TreeView implements Disposable {
     if (targetNode === undefined) return;
     const offset = await this.model.findNodeOffset(targetNode.makeView());
     if (offset === undefined) return;
-    await this.nvim.call("coc#util#jumpTo", [offset - 1, 1]);
+    await this.nvim.call(Commands.MOVE_TO, [offset - 1, 1]);
   }
 
   public async executeCommand(): Promise<void> {

--- a/src/tvp/treeviews.ts
+++ b/src/tvp/treeviews.ts
@@ -6,6 +6,7 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 import { TreeModel } from "./model";
 import { TreeView, TreeViewDescription } from "./treeview";
 import { sequence } from "./utils";
+import { Commands } from "../commands";
 
 interface WindowWithTree {
   window: Window;
@@ -180,7 +181,7 @@ export class TreeViewsManager implements Disposable {
     const model = this.view2treemodel.get(viewId);
     model?.show();
     if (mbTreeView !== undefined) {
-      await this.nvim.call("coc#util#jumpTo", [0, 1]);
+      await this.nvim.call(Commands.MOVE_TO, [0, 1]);
     } else if (model !== undefined) {
       const buffer = await this.nvim.buffer;
       const treeView = new TreeView(


### PR DESCRIPTION
This was removed and replaced with the `coc#cursor#move_to` in https://github.com/neoclide/coc.nvim/commit/00ed6677383e56d79cb2812bfe954f424bb15ded

Close #426 