### PR TITLE
Bump default server version of Metals to 0.10.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         },
         "metals.serverVersion": {
           "type": "string",
-          "default": "0.10.5",
+          "default": "0.10.6",
           "markdownDescription": "The version of the Metals server artifact. Requires reloading the window.\n\n**Change only if you know what you're doing**"
         },
         "metals.serverProperties": {


### PR DESCRIPTION
See release notes for 0.10.6 [here][1].

[1]: https://scalameta.org/metals/blog/2021/09/06/tungsten/